### PR TITLE
dropped items shouldn't disappear into the eather

### DIFF
--- a/src/InventoryUI.cpp
+++ b/src/InventoryUI.cpp
@@ -5,6 +5,7 @@
 #include "GameObjects.hpp"
 #include "Helper.hpp"
 #include "Inventory.hpp"
+#include "Map.hpp"
 #include "Math.hpp"
 #include "Model.hpp"
 #include "Sound.hpp"
@@ -99,7 +100,6 @@ namespace
     uint8_t previousSelection;
     uint8_t menuSelected;
     uint8_t sortSelected;
-    uint8_t dropSelected;
     uint8_t focusedWindow;
     uint8_t repeatTimer;
 
@@ -109,9 +109,6 @@ namespace
     SimpleTextSprite moveString(704 + 16, 256 + 180);
     SimpleTextSprite sortString(704 + 32, 256 + 180);
     SimpleTextSprite dropString(704 + 48, 256 + 180);
-    SimpleTextSprite youSureString(704 + 0, 256 + 192);
-    SimpleTextSprite yesString(704 + 48, 256 + 192);
-    SimpleTextSprite noString(704 + 56, 256 + 192);
     SimpleTextSprite descString(704 + 0, 256 + 204);
     SimpleTextSprite sortBattleString(704 + 0, 256 + 240);
     SimpleTextSprite sortRaiseString(704 + 16, 256 + 240);
@@ -208,9 +205,6 @@ namespace
         moveString.draw(&vanillaFont, "Move");
         sortString.draw(&vanillaFont, "Sort");
         dropString.draw(&vanillaFont, "Drop");
-        youSureString.draw(&vanillaFont, "Are you sure?");
-        yesString.draw(&vanillaFont, "Yes");
-        noString.draw(&vanillaFont, "No");
 
         sortBattleString.draw(&vanillaFont, "Battle");
         sortRaiseString.draw(&vanillaFont, "Raise");
@@ -369,62 +363,6 @@ namespace
         createAnimatedUIBox(3, 1, 0, &final, &start, tickSortOption, renderSortOption);
     }
 
-    static void tickDropOption(int32_t instanceId)
-    {
-        if (focusedWindow != 3) return;
-
-        if (isInventoryKeyDownRepeat(InputButtons::BUTTON_LEFT) && dropSelected > 0)
-        {
-            playSound(0, 2);
-            dropSelected--;
-        }
-        if (isInventoryKeyDownRepeat(InputButtons::BUTTON_RIGHT) && dropSelected < 1)
-        {
-            playSound(0, 2);
-            dropSelected++;
-        }
-
-        if (isInventoryKeyDown(InputButtons::BUTTON_TRIANGLE)) { removeAnimatedUIBox(3, nullptr); }
-        else if (isInventoryKeyDown(InputButtons::BUTTON_CROSS))
-        {
-            removeAnimatedUIBox(3, nullptr);
-            state         = 61;
-            focusedWindow = -1;
-
-            if (dropSelected == 0)
-                removeItem(INVENTORY_ITEM_TYPES[INVENTORY_POINTER], INVENTORY_ITEM_AMOUNTS[INVENTORY_POINTER]);
-        }
-    }
-
-    static void renderDropOption(int32_t instanceId)
-    {
-        auto baseX = UI_BOX_DATA[3].finalPos.x;
-        auto baseY = UI_BOX_DATA[3].finalPos.y;
-
-        youSureString.render(baseX + 12, baseY + 8, 9, 3, 1);
-        yesString.render(baseX + 23, baseY + 32, 9, 3, 1);
-        noString.render(baseX + 75, baseY + 32, 9, 3, 1);
-
-        renderSelectionCursor(baseX + 18 + dropSelected * 52, baseY + 30, 42, 16, 3);
-    }
-
-    void createDropOptions()
-    {
-        dropSelected  = 1;
-        focusedWindow = 3;
-        state         = 52;
-
-        constexpr RECT final = {.x = -64, .y = -38, .width = 128, .height = 53};
-        RECT start           = {
-                      .x      = static_cast<int16_t>(UI_BOX_DATA[2].finalPos.x + 9),
-                      .y      = static_cast<int16_t>(UI_BOX_DATA[2].finalPos.y + 60),
-                      .width  = 40,
-                      .height = 16,
-        };
-
-        createAnimatedUIBox(3, 1, 0, &final, &start, tickDropOption, renderDropOption);
-    }
-
     void tickInventoryOptions(int32_t instanceId)
     {
         if (focusedWindow != 2) return;
@@ -471,7 +409,18 @@ namespace
                 }
                 case 3:
                 {
-                    createDropOptions();
+                    auto type    = INVENTORY_ITEM_TYPES[INVENTORY_POINTER];
+                    auto nameIdx = INVENTORY_ITEM_NAMES[INVENTORY_POINTER];
+                    spawnDroppedItem(&TAMER_ENTITY, type);
+                    setIsStandingOnDrop(true);
+                    removeItem(type, 1);
+                    if (INVENTORY_ITEM_TYPES[INVENTORY_POINTER] != ItemType::NONE)
+                    {
+                        uint8_t buf[8];
+                        sprintf(buf, "%2d", INVENTORY_ITEM_AMOUNTS[INVENTORY_POINTER]);
+                        itemAmounts[nameIdx].draw(&fixedNumbersFont, buf);
+                    }
+                    removeAnimatedUIBox(2, nullptr);
                     break;
                 }
             }

--- a/src/InventoryUI.cpp
+++ b/src/InventoryUI.cpp
@@ -411,9 +411,10 @@ namespace
                 {
                     auto type    = INVENTORY_ITEM_TYPES[INVENTORY_POINTER];
                     auto nameIdx = INVENTORY_ITEM_NAMES[INVENTORY_POINTER];
-                    spawnDroppedItem(&TAMER_ENTITY, type);
+                    auto amount  = INVENTORY_ITEM_AMOUNTS[INVENTORY_POINTER];
+                    spawnDroppedItem(&TAMER_ENTITY, type, amount);
                     setIsStandingOnDrop(true);
-                    removeItem(type, 1);
+                    removeItem(type, amount);
                     if (INVENTORY_ITEM_TYPES[INVENTORY_POINTER] != ItemType::NONE)
                     {
                         uint8_t buf[8];

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -882,7 +882,11 @@ extern "C"
         renderDroppedItemShadow(&DROPPED_ITEMS[instanceId]);
     }
 
-    void spawnDroppedItem(Entity* entity, ItemType item)
+    static uint8_t DROPPED_ITEM_AMOUNTS[10] = {0};
+
+    uint8_t getDroppedItemAmount(int32_t dropId) { return DROPPED_ITEM_AMOUNTS[dropId]; }
+
+    void spawnDroppedItem(Entity* entity, ItemType item, uint8_t amount)
     {
         for (int32_t i = 0; i < 10; i++)
         {
@@ -894,6 +898,7 @@ extern "C"
             data.spriteLocation.y = 0;
             data.spriteLocation.z = entity->posData->location.z;
             getModelTile(&entity->posData->location, &data.tileX, &data.tileY);
+            DROPPED_ITEM_AMOUNTS[i] = amount;
             addObject(ObjectID::DROPPED_ITEM, i, nullptr, renderDroppedItem);
             return;
         }
@@ -920,7 +925,8 @@ extern "C"
     void deleteDroppedItem(int32_t instanceId)
     {
         removeObject(ObjectID::DROPPED_ITEM, instanceId);
-        DROPPED_ITEMS[instanceId].type = ItemType::NONE;
+        DROPPED_ITEMS[instanceId].type   = ItemType::NONE;
+        DROPPED_ITEM_AMOUNTS[instanceId] = 0;
     }
 
     void clearDroppedItems()
@@ -931,7 +937,8 @@ extern "C"
 
     bool pickupItem(int32_t dropId)
     {
-        if (giveItem(DROPPED_ITEMS[dropId].type, 1))
+        const uint8_t amount = DROPPED_ITEM_AMOUNTS[dropId] != 0 ? DROPPED_ITEM_AMOUNTS[dropId] : 1;
+        if (giveItem(DROPPED_ITEMS[dropId].type, amount))
         {
             deleteDroppedItem(dropId);
             return true;

--- a/src/Map.hpp
+++ b/src/Map.hpp
@@ -33,7 +33,8 @@ extern "C"
     void setImpassableSquare(int32_t tileX, int32_t tileY, int32_t radius);
     void setMapLayerEnabled(int32_t val);
     void updateMapLightState();
-    void spawnDroppedItem(Entity* entity, ItemType item);
+    void spawnDroppedItem(Entity* entity, ItemType item, uint8_t amount = 1);
+    uint8_t getDroppedItemAmount(int32_t dropId);
     void initializeMap();
     void initializeDrawingOffsets();
     void updateMapTile();

--- a/src/Tamer.cpp
+++ b/src/Tamer.cpp
@@ -987,6 +987,8 @@ extern "C"
     {
         return TAMER_ENTITY.isOnScreen;
     }
+
+    void setIsStandingOnDrop(bool value) { isStandingOnDrop = value; }
 }
 
 static void tickTamerWaypoints()

--- a/src/Tamer.cpp
+++ b/src/Tamer.cpp
@@ -445,7 +445,15 @@ extern "C"
             drawStringNew(&vanillaFont, getDigimonData(DigimonType::TAMER)->name, 704 + 0, 256 + 12);
             auto offset = drawStringNew(&vanillaFont, findItemStr, 704 + 0, 256 + 24) / 4;
             setTextColor(5);
-            drawStringNew(&vanillaFont, getItem(itemType)->name, 704 + offset + 1, 256 + 24);
+            auto nameOffset = drawStringNew(&vanillaFont, getItem(itemType)->name, 704 + offset + 1, 256 + 24) / 4;
+            const uint8_t pickupAmount = getDroppedItemAmount(pickedDropId);
+            if (pickupAmount > 1)
+            {
+                setTextColor(3);
+                uint8_t suffix[8];
+                sprintf(suffix, " x%d", pickupAmount);
+                drawStringNew(&vanillaFont, suffix, 704 + offset + 1 + nameOffset, 256 + 24);
+            }
             setTextColor(1);
 
             takeItemFrameCount = 0;

--- a/src/Tamer.hpp
+++ b/src/Tamer.hpp
@@ -5,6 +5,7 @@ extern "C"
 {
     void setupTamerOnWarp(int32_t posX, int32_t posY, int32_t posZ, int32_t rotation);
     void Tamer_setState(uint8_t state);
+    void setIsStandingOnDrop(bool value);
     void Tamer_setSubState(uint8_t state);
     void Tamer_setFullState(uint8_t state, uint8_t subState);
     uint8_t Tamer_getState();


### PR DESCRIPTION
Currently when an item is dropped, it disappears into the eather, this behavior from the vanilla game never made sense to me.

This is a small patch to fix it, and remove the confirmation, since it's not needed as now you can recover the dropped item.