### PR TITLE
Port processInput / isKeyDown to C++ and add auto-repeat input state

### DIFF
--- a/GameData.asm
+++ b/GameData.asm
@@ -53,6 +53,13 @@
   .fill 0x800f1498-.
 .endarea
 
+.org 0x800fbf84
+.area 0x800fc08c-.
+
+  .notice "Cave5-sub1 Empty space left: " + (0x800fc08c-.) + " bytes"
+  .fill 0x800fc08c-.
+.endarea
+
 ;;; Initialized memory, in vanilla only for data
 .notice "Start Memory Caves"
 

--- a/Input.asm
+++ b/Input.asm
@@ -1,6 +1,12 @@
 .open "work/DIGIMON/SLUS_010.32",0x80090000
 .psx
 
+.org 0x800fbf84
+.area 24
+  j inputInit
+  nop
+.endarea
+
 .org 0x800fbf9c
 .area 188
   j processInput

--- a/Input.asm
+++ b/Input.asm
@@ -1,0 +1,16 @@
+.open "work/DIGIMON/SLUS_010.32",0x80090000
+.psx
+
+.org 0x800fbf9c
+.area 188
+  j processInput
+  nop
+.endarea
+
+.org 0x800fc054
+.area 56
+  j isKeyDown
+  nop
+.endarea
+
+.close

--- a/Input.asm
+++ b/Input.asm
@@ -1,22 +1,141 @@
 .open "work/DIGIMON/SLUS_010.32",0x80090000
 .psx
 
-.org 0x800fbf84
-.area 24
-  j inputInit
-  nop
-.endarea
+.org 0x80105a80
+  jal inputInit
+.org 0x800fabb0
+  jal isKeyDown
+.org 0x800fac48
+  jal isKeyDown
+.org 0x800faccc
+  jal isKeyDown
+.org 0x800fad18
+  jal isKeyDown
+.org 0x800fad64
+  jal isKeyDown
+.org 0x800fb098
+  jal isKeyDown
+.org 0x800fb190
+  jal isKeyDown
+.org 0x800fb224
+  jal isKeyDown
+.org 0x800fb2ac
+  jal isKeyDown
+.org 0x800fb2d8
+  jal isKeyDown
+.org 0x800fb304
+  jal isKeyDown
+.org 0x800fb900
+  jal isKeyDown
+.org 0x800fb92c
+  jal isKeyDown
+.org 0x800fb954
+  jal isKeyDown
+.org 0x800fb980
+  jal isKeyDown
+.org 0x800ffc54
+  jal isKeyDown
+.org 0x800ffc88
+  jal isKeyDown
+.org 0x800ffd28
+  jal isKeyDown
+.org 0x800ffd88
+  jal isKeyDown
+.org 0x800ffe68
+  jal isKeyDown
+.org 0x80100018
+  jal isKeyDown
+.org 0x80100068
+  jal isKeyDown
+.org 0x80107edc
+  jal isKeyDown
+.org 0x80107fa8
+  jal isKeyDown
+.org 0x80107ff0
+  jal isKeyDown
+.org 0x8010803c
+  jal isKeyDown
+.org 0x801083ec
+  jal isKeyDown
+.org 0x80108418
+  jal isKeyDown
+.org 0x80108440
+  jal isKeyDown
+.org 0x8010847c
+  jal isKeyDown
+.org 0x801084a8
+  jal isKeyDown
+.org 0x801084d4
+  jal isKeyDown
+.org 0x80108500
+  jal isKeyDown
+.org 0x80108550
+  jal isKeyDown
+.org 0x801085a0
+  jal isKeyDown
+.org 0x80109284
+  jal isKeyDown
+.org 0x80109314
+  jal isKeyDown
+.org 0x8010933c
+  jal isKeyDown
+.org 0x8010938c
+  jal isKeyDown
+.org 0x80109558
+  jal isKeyDown
+.org 0x80109614
+  jal isKeyDown
+.org 0x80109640
+  jal isKeyDown
+.org 0x80109690
+  jal isKeyDown
+.org 0x8010985c
+  jal isKeyDown
+.org 0x8010990c
+  jal isKeyDown
+.org 0x80109938
+  jal isKeyDown
+.org 0x8010998c
+  jal isKeyDown
+.org 0x8010a0bc
+  jal isKeyDown
+.org 0x8010a0f4
+  jal isKeyDown
+.org 0x8010a2f8
+  jal isKeyDown
+.org 0x8010a324
+  jal isKeyDown
+.org 0x8010a344
+  jal isKeyDown
+.org 0x8010a370
+  jal isKeyDown
+.org 0x8010a39c
+  jal isKeyDown
+.org 0x8010a3c8
+  jal isKeyDown
+.org 0x8010a3ec
+  jal isKeyDown
 
-.org 0x800fbf9c
-.area 188
-  j processInput
-  nop
-.endarea
+.close
 
-.org 0x800fc054
-.area 56
-  j isKeyDown
-  nop
-.endarea
+.open "work/DIGIMON/DGET_REL.BIN",0x80080800
+.psx
+
+.org 0x80081380
+  jal isKeyDown
+.org 0x800813ac
+  jal isKeyDown
+.org 0x8008143c
+  jal isKeyDown
+.org 0x80081484
+  jal isKeyDown
+.org 0x800814c8
+  jal isKeyDown
+.org 0x80081510
+  jal isKeyDown
+.org 0x80081554
+  jal isKeyDown
+.org 0x80081960
+  jal isKeyDown
 
 .close

--- a/SLUS_labels.asm
+++ b/SLUS_labels.asm
@@ -13,7 +13,6 @@
 .definelabel setTrigger,                0x801065c0
 .definelabel readPStat,                 0x801062e0
 .definelabel writePStat,                0x80106474
-.definelabel isKeyDown,                 0x800fc054
 .definelabel unlockMedal,               0x800ff830
 .definelabel hasMedal,                  0x800ff85c
 .definelabel getCardAmount,             0x801067ec
@@ -38,7 +37,6 @@
 .definelabel initializeUnknownModelObject,0x800f1878
 .definelabel initializeFontCLUT,        0x8010cb3c
 .definelabel initializeScripts,         0x801059c8
-.definelabel processInput,              0x800fbf9c
 .definelabel tickTextboxHandling,       0x80100258
 .definelabel initializeNamingBuffer,    0x8010c70c
 .definelabel initializeTextbox,         0x8010020c
@@ -218,6 +216,10 @@
 .definelabel UI_BOX_DATA, 0x8013d390
 .definelabel POLLED_INPUT, 0x80134ee4
 .definelabel POLLED_INPUT_PREVIOUS, 0x80134ee8
+.definelabel INPUT_REPEAT_COUNTER, 0x80135016
+.definelabel INPUT_REPEAT_MASK, 0x8013501c
+.definelabel INPUT_FRESH_MASK, 0x80135020
+.definelabel INPUT_PENDING_MASK, 0x80135024
 .definelabel TARGET_MAP, 0x80134de0
 .definelabel CURRENT_EXIT, 0x80134daa
 .definelabel BATTLE_TOGGLE_LIFEBAR, 0x80134d64

--- a/patches.asm
+++ b/patches.asm
@@ -42,3 +42,4 @@
 .include "Fishing.asm"
 .include "VanillaText.asm"
 .include "Pause.asm"
+.include "Input.asm"

--- a/src/DebugMenu.cpp
+++ b/src/DebugMenu.cpp
@@ -1,6 +1,7 @@
 #include "DebugMenu.hpp"
 
 #include "Helper.hpp"
+#include "Input.hpp"
 #include "Math.hpp"
 #include "Sound.hpp"
 #include "UIElements.hpp"

--- a/src/DigimonMenu.cpp
+++ b/src/DigimonMenu.cpp
@@ -1,6 +1,7 @@
 #include "Entity.hpp"
 #include "Font.hpp"
 #include "Helper.hpp"
+#include "Input.hpp"
 #include "Math.hpp"
 #include "Sound.hpp"
 #include "StatsView.hpp"

--- a/src/GameMenu.cpp
+++ b/src/GameMenu.cpp
@@ -9,6 +9,7 @@
 #include "GameObjects.hpp"
 #include "GameTime.hpp"
 #include "Helper.hpp"
+#include "Input.hpp"
 #include "InventoryUI.hpp"
 #include "Math.hpp"
 #include "Partner.hpp"

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -45,6 +45,14 @@ bool isKeyPressed(InputButtons button)
 
 extern "C"
 {
+    void inputInit()
+    {
+        INPUT_PENDING_MASK   = 0;
+        INPUT_FRESH_MASK     = 0xFFFFFFFFu;
+        INPUT_REPEAT_MASK    = 0;
+        INPUT_REPEAT_COUNTER = 0;
+    }
+
     bool isKeyDown(uint16_t keyMask)
     {
         if ((INPUT_PENDING_MASK & keyMask) == 0) return false;

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -2,6 +2,37 @@
 
 #include "extern/dw1.hpp"
 
+namespace
+{
+    constexpr uint16_t REPEAT_FIRST_FIRE = 6;
+    constexpr uint16_t REPEAT_WRAP       = 8;
+    static_assert(REPEAT_WRAP > REPEAT_FIRST_FIRE);
+
+    inline uint32_t tickAutoRepeat(uint32_t held, uint32_t prev)
+    {
+        if (held != prev)
+        {
+            INPUT_REPEAT_COUNTER = 0;
+            INPUT_FRESH_MASK |= INPUT_REPEAT_MASK;
+            return 0;
+        }
+
+        const uint16_t cnt = INPUT_REPEAT_COUNTER;
+        uint32_t      fire = 0;
+        if (cnt == REPEAT_WRAP)
+        {
+            INPUT_REPEAT_COUNTER = REPEAT_FIRST_FIRE;
+            fire                 = held;
+        }
+        else if (cnt == REPEAT_FIRST_FIRE)
+        {
+            fire = held;
+        }
+        INPUT_REPEAT_COUNTER = static_cast<uint16_t>(INPUT_REPEAT_COUNTER + 1);
+        return fire;
+    }
+}
+
 bool isKeyDownPolled(InputButtons button)
 {
     return ((POLLED_INPUT & ~POLLED_INPUT_PREVIOUS) & button) != 0;
@@ -10,4 +41,31 @@ bool isKeyDownPolled(InputButtons button)
 bool isKeyPressed(InputButtons button)
 {
     return (POLLED_INPUT & button) != 0;
+}
+
+extern "C"
+{
+    bool isKeyDown(uint16_t keyMask)
+    {
+        if ((INPUT_PENDING_MASK & keyMask) == 0) return false;
+        INPUT_FRESH_MASK &= ~static_cast<uint32_t>(keyMask);
+        return true;
+    }
+
+    uint32_t processInput()
+    {
+        const uint32_t polled = POLLED_INPUT;
+        INPUT_FRESH_MASK |= ~polled;
+
+        const uint32_t held = polled & INPUT_REPEAT_MASK;
+        if (held == 0) INPUT_REPEAT_COUNTER = 0;
+
+        const uint32_t fire = (INPUT_REPEAT_MASK != 0)
+            ? tickAutoRepeat(held, POLLED_INPUT_PREVIOUS & INPUT_REPEAT_MASK)
+            : 0u;
+
+        const uint32_t result = fire | (polled & INPUT_FRESH_MASK);
+        INPUT_PENDING_MASK    = result;
+        return result;
+    }
 }

--- a/src/Input.hpp
+++ b/src/Input.hpp
@@ -2,5 +2,15 @@
 
 #include "extern/dw1.hpp"
 
+extern "C"
+{
+    /*
+     * Checks if a button has been pressed and consumes it (i.e. subsequent checks for the same button within the same
+     * tick return false).
+     */
+    bool isKeyDown(uint16_t keyMask);
+    uint32_t processInput();
+}
+
 bool isKeyDownPolled(InputButtons button);
 bool isKeyPressed(InputButtons button);

--- a/src/PlayerCardView.cpp
+++ b/src/PlayerCardView.cpp
@@ -3,6 +3,7 @@
 #include "DigimonData.hpp"
 #include "Files.hpp"
 #include "Helper.hpp"
+#include "Input.hpp"
 #include "Math.hpp"
 #include "Sound.hpp"
 #include "UIElements.hpp"

--- a/src/PlayerChartView.cpp
+++ b/src/PlayerChartView.cpp
@@ -3,6 +3,7 @@
 
 #include "DigimonData.hpp"
 #include "Helper.hpp"
+#include "Input.hpp"
 #include "Math.hpp"
 #include "Sound.hpp"
 #include "UIElements.hpp"

--- a/src/PlayerMedalView.cpp
+++ b/src/PlayerMedalView.cpp
@@ -1,4 +1,5 @@
 #include "Helper.hpp"
+#include "Input.hpp"
 #include "Math.hpp"
 #include "Model.hpp"
 #include "Sound.hpp"

--- a/src/PlayerMenu.cpp
+++ b/src/PlayerMenu.cpp
@@ -1,6 +1,7 @@
 #include "Files.hpp"
 #include "Font.hpp"
 #include "Helper.hpp"
+#include "Input.hpp"
 #include "Math.hpp"
 #include "PlayerCardView.hpp"
 #include "PlayerChartView.hpp"

--- a/src/TechView.cpp
+++ b/src/TechView.cpp
@@ -3,6 +3,7 @@
 #include "Entity.hpp"
 #include "Font.hpp"
 #include "Helper.hpp"
+#include "Input.hpp"
 #include "Math.hpp"
 #include "Partner.hpp"
 #include "Sound.hpp"

--- a/src/extern/dw1.hpp
+++ b/src/extern/dw1.hpp
@@ -1800,11 +1800,6 @@ extern "C"
     bool hasMedal(Medal medal);
     void unlockMedal(Medal medal);
     uint8_t getCardAmount(uint8_t cardId);
-    /*
-     * Checks if a button has been pressed and consumes it (i.e. subsequent checks for the same button within the same
-     * tick return false).
-     */
-    bool isKeyDown(uint16_t keyMask);
     int32_t main();
     uint8_t readPStat(int32_t address);
     void writePStat(int32_t address, uint8_t value);
@@ -1818,7 +1813,6 @@ extern "C"
     bool hasDigimonRaised(DigimonType type);
     void initializeFontCLUT();
     void initializeScripts();
-    uint32_t processInput();
     void tickTextboxHandling(int32_t mode);
     void initializeNamingBuffer(int32_t mode);
     void initializeTextbox();

--- a/src/extern/dw1.hpp
+++ b/src/extern/dw1.hpp
@@ -1594,6 +1594,10 @@ extern "C"
     extern UIBoxData UI_BOX_DATA[6];
     extern uint32_t POLLED_INPUT;
     extern uint32_t POLLED_INPUT_PREVIOUS;
+    extern uint16_t INPUT_REPEAT_COUNTER;
+    extern uint32_t INPUT_REPEAT_MASK;
+    extern uint32_t INPUT_FRESH_MASK;
+    extern uint32_t INPUT_PENDING_MASK;
     extern MapWarps MAP_WARPS;
     extern uint16_t CHAR_TO_GLYPH_TABLE[80];
     extern GlyphData GLYPH_DATA[79];
@@ -1814,7 +1818,7 @@ extern "C"
     bool hasDigimonRaised(DigimonType type);
     void initializeFontCLUT();
     void initializeScripts();
-    void processInput();
+    uint32_t processInput();
     void tickTextboxHandling(int32_t mode);
     void initializeNamingBuffer(int32_t mode);
     void initializeTextbox();


### PR DESCRIPTION
from what I can tell, `processInput` callers in vanilla discard the return value, so the signature change is binary-compatible at the call sites that haven't been touched yet. (but my asm can use some brushing up, so double check, haha)