### PR TITLE
Refactor AtlasFont to support all settings in every situation

### DIFF
--- a/src/AtlasFont.cpp
+++ b/src/AtlasFont.cpp
@@ -340,6 +340,8 @@ void AtlasString::setPosition(int32_t x, int32_t y)
 
 void AtlasString::render(int32_t depth) const
 {
+    if(data.size() == 0) return;
+
     auto* sprites = reinterpret_cast<SPRT*>(libgs_GsGetWorkBase());
     dtl::copy(data.begin(), data.end(), sprites);
     for (int32_t i = 0; i < data.size(); i++)

--- a/src/AtlasFont.cpp
+++ b/src/AtlasFont.cpp
@@ -3,6 +3,8 @@
 #include "Font.hpp"
 #include "Helper.hpp"
 #include "Math.hpp"
+#include "Timestamp.hpp"
+#include "UIElements.hpp"
 #include "Utils.hpp"
 #include "extern/dtl/runtime_array.hpp"
 
@@ -101,7 +103,7 @@ namespace
         return {rect, glyph_width};
     }
 
-    SPRT getSPRT(const RECT& data, int32_t x, int32_t y, RGB8 color, bool hasShadow)
+    constexpr SPRT getSPRT(const RECT& data, int32_t x, int32_t y, RGB8 color, uint8_t baseClut)
     {
         SPRT prim;
         prim.tag.num = 4;
@@ -109,7 +111,7 @@ namespace
         prim.r       = (color.red + 1) / 2;
         prim.g       = (color.green + 1) / 2;
         prim.b       = (color.blue + 1) / 2;
-        prim.clut    = getClut(CLUT_X, CLUT_Y + hasShadow);
+        prim.clut    = getClut(CLUT_X, CLUT_Y + baseClut);
         prim.x       = x;
         prim.y       = y;
         prim.u       = 4 * (data.x % 64);
@@ -207,7 +209,7 @@ Position AtlasFont::getPosition(const uint8_t* string, const RenderSettings& set
 {
     int16_t x = settings.x;
     int16_t y = settings.y;
-    if (settings.width > 0)
+    if (settings.width > 0 && settings.alignX != AlignmentX::LEFT)
     {
         auto width = getWidth(string);
         switch (settings.alignX)
@@ -247,7 +249,7 @@ void AtlasFont::renderSlow(const uint8_t* string, int32_t depth, const RenderSet
     {
         auto index = font->getGlyphIndex(*itr++);
         auto glyph = glyphs[index];
-        prim2[i]   = getSPRT(glyph.rect, pos.x, pos.y, settings.color, settings.hasShadow);
+        prim2[i]   = getSPRT(glyph.rect, pos.x, pos.y, settings.color, settings.baseClut);
         pos.x += glyph.width;
         addPrim(ACTIVE_ORDERING_TABLE->origin + depth, reinterpret_cast<GsOT_TAG*>(prim2 + i));
     }
@@ -274,13 +276,12 @@ AtlasString AtlasFont::render(const uint8_t* string, const RenderSettings& setti
 
     for (int32_t i = 0; i < size; i++)
     {
-        auto index = font->getGlyphIndex(*itr++);
-        auto glyph = glyphs[index];
-        data[i]    = getSPRT(glyph.rect, pos.x + totalWidth, pos.y, settings.color, settings.hasShadow);
+        auto index = font->getGlyphIndex(*itr++); 
+        const auto& glyph = glyphs[index];
+        data[i]    = getSPRT(glyph.rect, pos.x + totalWidth, pos.y, settings.color, settings.baseClut);
         totalWidth += glyph.width;
     }
-
-    return AtlasString(data, tpage, totalWidth, font->height);
+    return AtlasString(dtl::move(data), tpage, totalWidth, font->height);
 }
 
 void AtlasString::enableShadow(bool enabled)

--- a/src/AtlasFont.cpp
+++ b/src/AtlasFont.cpp
@@ -101,15 +101,15 @@ namespace
         return {rect, glyph_width};
     }
 
-    SPRT getSPRT(const RECT& data, int32_t x, int32_t y, RenderSettings settings)
+    SPRT getSPRT(const RECT& data, int32_t x, int32_t y, RGB8 color, bool hasShadow)
     {
         SPRT prim;
         prim.tag.num = 4;
         prim.code    = 0x64;
-        prim.r       = (settings.r + 1) / 2;
-        prim.g       = (settings.g + 1) / 2;
-        prim.b       = (settings.b + 1) / 2;
-        prim.clut    = getClut(CLUT_X, CLUT_Y + settings.hasShadow);
+        prim.r       = (color.red + 1) / 2;
+        prim.g       = (color.green + 1) / 2;
+        prim.b       = (color.blue + 1) / 2;
+        prim.clut    = getClut(CLUT_X, CLUT_Y + hasShadow);
         prim.x       = x;
         prim.y       = y;
         prim.u       = 4 * (data.x % 64);
@@ -188,13 +188,57 @@ void AtlasFont::init(Font* f, int32_t x, int32_t y, int32_t maxWidth)
     }
 }
 
-void AtlasFont::renderSlow(const char* string, int32_t x, int32_t y, int32_t depth, RenderSettings settings) const
+int32_t AtlasFont::getWidth(const uint8_t* string) const
 {
-    renderSlow(reinterpret_cast<const uint8_t*>(string), x, y, depth, settings);
+    auto size = jis_len(string);
+    JISIterator itr{string};
+    auto width = 0;
+
+    for (int32_t i = 0; i < size; i++)
+    {
+        auto index = font->getGlyphIndex(*itr++);
+        width += glyphs[index].width;
+    }
+
+    return width;
 }
 
-void AtlasFont::renderSlow(const uint8_t* string, int32_t x, int32_t y, int32_t depth, RenderSettings settings) const
+Position AtlasFont::getPosition(const uint8_t* string, const RenderSettings& settings) const
 {
+    int16_t x = settings.x;
+    int16_t y = settings.y;
+    if (settings.width > 0)
+    {
+        auto width = getWidth(string);
+        switch (settings.alignX)
+        {
+            case AlignmentX::LEFT: x += 0; break;
+            case AlignmentX::CENTER: x += (settings.width - width) / 2; break;
+            case AlignmentX::RIGHT: x += (settings.width - width); break;
+        }
+    }
+
+    if (settings.height > 0)
+    {
+        switch (settings.alignY)
+        {
+            case AlignmentY::TOP: y += 0; break;
+            case AlignmentY::CENTER: y += (settings.height - font->height) / 2; break;
+            case AlignmentY::BOTTOM: y += (settings.height - font->height); break;
+        }
+    }
+
+    return {x, y};
+}
+
+void AtlasFont::renderSlow(const char* string, int32_t depth, const RenderSettings& settings) const
+{
+    renderSlow(reinterpret_cast<const uint8_t*>(string), depth, settings);
+}
+
+void AtlasFont::renderSlow(const uint8_t* string, int32_t depth, const RenderSettings& settings) const
+{
+    auto pos  = getPosition(string, settings);
     auto size = jis_len(string);
     JISIterator itr{string};
 
@@ -203,8 +247,8 @@ void AtlasFont::renderSlow(const uint8_t* string, int32_t x, int32_t y, int32_t 
     {
         auto index = font->getGlyphIndex(*itr++);
         auto glyph = glyphs[index];
-        prim2[i]   = getSPRT(glyph.rect, x, y, settings);
-        x += glyph.width;
+        prim2[i]   = getSPRT(glyph.rect, pos.x, pos.y, settings.color, settings.hasShadow);
+        pos.x += glyph.width;
         addPrim(ACTIVE_ORDERING_TABLE->origin + depth, reinterpret_cast<GsOT_TAG*>(prim2 + i));
     }
 
@@ -215,13 +259,14 @@ void AtlasFont::renderSlow(const uint8_t* string, int32_t x, int32_t y, int32_t 
     libgs_GsSetWorkBase(prim + 1);
 }
 
-AtlasString AtlasFont::render(const char* string, int32_t x, int32_t y, RenderSettings settings) const
+AtlasString AtlasFont::render(const char* string, const RenderSettings& settings) const
 {
-    return render(reinterpret_cast<const uint8_t*>(string), x, y, settings);
+    return render(reinterpret_cast<const uint8_t*>(string), settings);
 }
 
-AtlasString AtlasFont::render(const uint8_t* string, int32_t x, int32_t y, RenderSettings settings) const
+AtlasString AtlasFont::render(const uint8_t* string, const RenderSettings& settings) const
 {
+    auto pos  = getPosition(string, settings);
     auto size = jis_len(string);
     JISIterator itr{string};
     dtl::runtime_array<SPRT> data(size);
@@ -231,7 +276,7 @@ AtlasString AtlasFont::render(const uint8_t* string, int32_t x, int32_t y, Rende
     {
         auto index = font->getGlyphIndex(*itr++);
         auto glyph = glyphs[index];
-        data[i]    = getSPRT(glyph.rect, x + totalWidth, y, settings);
+        data[i]    = getSPRT(glyph.rect, pos.x + totalWidth, pos.y, settings.color, settings.hasShadow);
         totalWidth += glyph.width;
     }
 
@@ -252,6 +297,11 @@ void AtlasString::setColor(uint8_t r, uint8_t g, uint8_t b)
         entry.g = (g + 1) / 2;
         entry.b = (b + 1) / 2;
     }
+}
+
+void AtlasString::setColor(RGB8 color)
+{
+    setColor(color.red, color.green, color.blue);
 }
 
 void AtlasString::setAlignment(RECT rect, AlignmentX alignX, AlignmentY alignY)

--- a/src/AtlasFont.cpp
+++ b/src/AtlasFont.cpp
@@ -157,7 +157,8 @@ void initFonts()
 
     // use space in ETCTIM8
     fontAtlasVanilla.init(&vanillaFont, 351, 176);
-    fontAtlas5px.init(&myFont5px, 350, 242);
+    // use space in ETCTIM1
+    fontAtlas5px.init(&myFont5px, 997, 480);
     // use space in ETCTIM5
     fontAtlas7px.init(&myFont7px, 768, 432);
     // use space below ETCTIM2

--- a/src/AtlasFont.hpp
+++ b/src/AtlasFont.hpp
@@ -6,9 +6,14 @@
 #include "extern/dw1.hpp"
 #include "extern/libgpu.hpp"
 
-constexpr RGB8 TEXT_COLOR_WHITE  = {.red = 0xd6, .green = 0xd6, .blue = 0xd6};
-constexpr RGB8 TEXT_COLOR_BLUE   = {.red = 0x29, .green = 0x8e, .blue = 0xd6};
-constexpr RGB8 TEXT_COLOR_YELLOW = {.red = 0xFF, .green = 0xFF, .blue = 0x53};
+constexpr RGB8 TEXT_COLOR_WHITE        = {.red = 0xd6, .green = 0xd6, .blue = 0xd6};
+constexpr RGB8 TEXT_COLOR_BLUE         = {.red = 0x29, .green = 0x8e, .blue = 0xd6};
+constexpr RGB8 TEXT_COLOR_YELLOW       = {.red = 0xFF, .green = 0xFF, .blue = 0x53};
+constexpr RGB8 TEXT_COLOR_LIGHT_YELLOW = {.red = 0xFF, .green = 0xFA, .blue = 0x75};
+constexpr RGB8 TEXT_COLOR_LIGHT_BLUE   = {.red = 0xAF, .green = 0xFF, .blue = 0xFF};
+constexpr RGB8 TEXT_COLOR_GREY         = {.red = 0x84, .green = 0x84, .blue = 0x84};
+constexpr RGB8 TEXT_COLOR_PINK         = {.red = 0xFF, .green = 0x32, .blue = 0x85};
+constexpr RGB8 TEXT_COLOR_GREEN        = {.red = 0x32, .green = 0xFF, .blue = 0x32};
 
 struct AtlasString
 {
@@ -45,7 +50,7 @@ struct RenderSettings
 {
     int16_t x;
     int16_t y;
-    bool hasShadow    = false;
+    uint8_t baseClut  = 0;
     RGB8 color        = TEXT_COLOR_WHITE;
     int16_t width     = 0;
     int16_t height    = 0;

--- a/src/AtlasFont.hpp
+++ b/src/AtlasFont.hpp
@@ -3,7 +3,12 @@
 #include "Font.hpp"
 #include "UIElements.hpp"
 #include "extern/dtl/runtime_array.hpp"
+#include "extern/dw1.hpp"
 #include "extern/libgpu.hpp"
+
+constexpr RGB8 TEXT_COLOR_WHITE  = {.red = 0xd6, .green = 0xd6, .blue = 0xd6};
+constexpr RGB8 TEXT_COLOR_BLUE   = {.red = 0x29, .green = 0x8e, .blue = 0xd6};
+constexpr RGB8 TEXT_COLOR_YELLOW = {.red = 0xFF, .green = 0xFF, .blue = 0x53};
 
 struct AtlasString
 {
@@ -24,6 +29,7 @@ struct AtlasString
     void render(int32_t depth) const;
     int32_t getWidth() const;
     void enableShadow(bool enabled);
+    void setColor(RGB8 color);
     void setColor(uint8_t r, uint8_t g, uint8_t b);
     void setPosition(int32_t x, int32_t y);
     void setAlignment(RECT rect, AlignmentX alignX, AlignmentY alignY);
@@ -37,10 +43,14 @@ struct AtlasGlyph
 
 struct RenderSettings
 {
-    bool hasShadow = false;
-    uint8_t r      = 0xd6;
-    uint8_t g      = 0xd6;
-    uint8_t b      = 0xd6;
+    int16_t x;
+    int16_t y;
+    bool hasShadow    = false;
+    RGB8 color        = TEXT_COLOR_WHITE;
+    int16_t width     = 0;
+    int16_t height    = 0;
+    AlignmentX alignX = AlignmentX::LEFT;
+    AlignmentY alignY = AlignmentY::TOP;
 };
 
 struct AtlasFont
@@ -49,12 +59,15 @@ public:
     AtlasFont();
     void init(Font* font, int32_t x, int32_t y, int32_t maxWidth = 64);
 
-    AtlasString render(const char* string, int32_t x, int32_t y, RenderSettings settings = {}) const;
-    AtlasString render(const uint8_t* string, int32_t x, int32_t y, RenderSettings settings = {}) const;
-    void renderSlow(const char* string, int32_t x, int32_t y, int32_t depth, RenderSettings settings = {}) const;
-    void renderSlow(const uint8_t* string, int32_t x, int32_t y, int32_t depth, RenderSettings settings = {}) const;
+    AtlasString render(const char* string, const RenderSettings& settings) const;
+    AtlasString render(const uint8_t* string, const RenderSettings& settings) const;
+    void renderSlow(const char* string, int32_t depth, const RenderSettings& settings) const;
+    void renderSlow(const uint8_t* string, int32_t depth, const RenderSettings& settings) const;
 
 private:
+    int32_t getWidth(const uint8_t* string) const;
+    Position getPosition(const uint8_t* string, const RenderSettings& settings) const;
+
     Font* font;
     dtl::runtime_array<AtlasGlyph> glyphs;
     uint8_t tpage;

--- a/src/AtlasFont.hpp
+++ b/src/AtlasFont.hpp
@@ -12,8 +12,10 @@ constexpr RGB8 TEXT_COLOR_YELLOW       = {.red = 0xFF, .green = 0xFF, .blue = 0x
 constexpr RGB8 TEXT_COLOR_LIGHT_YELLOW = {.red = 0xFF, .green = 0xFA, .blue = 0x75};
 constexpr RGB8 TEXT_COLOR_LIGHT_BLUE   = {.red = 0xAF, .green = 0xFF, .blue = 0xFF};
 constexpr RGB8 TEXT_COLOR_GREY         = {.red = 0x84, .green = 0x84, .blue = 0x84};
+constexpr RGB8 TEXT_COLOR_LIGHT_GREY   = {.red = 0xb7, .green = 0xb7, .blue = 0xb7};
 constexpr RGB8 TEXT_COLOR_PINK         = {.red = 0xFF, .green = 0x32, .blue = 0x85};
 constexpr RGB8 TEXT_COLOR_GREEN        = {.red = 0x32, .green = 0xFF, .blue = 0x32};
+constexpr RGB8 TEXT_COLOR_X_BLUE       = {.red = 0x78, .green = 0x7c, .blue = 0xcf}; // PS1 X Button
 
 struct AtlasString
 {

--- a/src/BattleEndBox.cpp
+++ b/src/BattleEndBox.cpp
@@ -74,9 +74,7 @@ namespace
     {
         uint8_t layer = 6 - index;
 
-        dtl::array<uint8_t, 16> string;
-        sprintf(string.data(), "%d", BITS_TO_GAIN);
-        getAtlasVanilla().renderSlow(string.data(), layer, {.x = -18, .y = 28});
+        getAtlasVanilla().renderSlow(format("%d", BITS_TO_GAIN).data(), layer, {.x = -18, .y = 28});
         data->bitString1.render(layer);
 
         if (BTL_END_BOX_TEXTBUFFER[0] != 0)
@@ -93,9 +91,7 @@ namespace
             .x = static_cast<int16_t>(UI_BOX_DATA[2].finalPos.x + 58),
             .y = static_cast<int16_t>(UI_BOX_DATA[2].finalPos.y + 10),
         };
-        dtl::array<uint8_t, 16> string;
-        sprintf(string.data(), "%d", MONEY);
-        getAtlasVanilla().renderSlow(string.data(), 4, settings);
+        getAtlasVanilla().renderSlow(format("%d", MONEY).data(), 4, settings);
         data->bitString2.render(4);
     }
 
@@ -139,9 +135,7 @@ namespace
                 .x = static_cast<int16_t>(box.finalPos.x + 0x8e),
                 .y = static_cast<int16_t>(box.finalPos.y + 9 + (i * 13)),
             };
-            dtl::array<uint8_t, 8> string;
-            sprintf(string.data(), "%d", STATS_GAINS.get(stat));
-            getAtlasVanilla().renderSlow(string.data(), layer, settings);
+            getAtlasVanilla().renderSlow(format("%d", STATS_GAINS.get(stat)).data(), layer, settings);
         }
 
         for (int32_t i = 0; i < 6; i++)
@@ -151,10 +145,7 @@ namespace
                 .y = static_cast<int16_t>(box.finalPos.y + 9 + (i * 13)),
             };
             auto stat = static_cast<Stat>(i);
-            dtl::array<uint8_t, 8> string;
-
-            sprintf(string.data(), "%d", INITIAL_COMBAT_STATS[0].get(stat));
-            getAtlasVanilla().renderSlow(string.data(), layer, settings);
+            getAtlasVanilla().renderSlow(format("%d", INITIAL_COMBAT_STATS[0].get(stat)).data(), layer, settings);
         }
 
         setTextColor(previous_color);

--- a/src/BattleEndBox.cpp
+++ b/src/BattleEndBox.cpp
@@ -28,7 +28,6 @@ namespace
 
     constexpr dtl::array<const char*, 6> statLabels{"HP", "MP", "Off", "Def", "Speed", "Brain"};
     constexpr auto bitsString = "Bits";
-    constexpr RenderSettings LABEL_SETTINGS{.r = 0xFF, .g = 0xFF, .b = 0x53};
 
     dtl::array<bool, 6> STAT_BOX_HAS_GAIN;
 
@@ -77,7 +76,7 @@ namespace
 
         dtl::array<uint8_t, 16> string;
         sprintf(string.data(), "%d", BITS_TO_GAIN);
-        getAtlasVanilla().renderSlow(string.data(), -18, 28, layer);
+        getAtlasVanilla().renderSlow(string.data(), layer, {.x = -18, .y = 28});
         data->bitString1.render(layer);
 
         if (BTL_END_BOX_TEXTBUFFER[0] != 0)
@@ -90,9 +89,13 @@ namespace
 
     void renderFinalBalance(int32_t)
     {
+        const RenderSettings settings{
+            .x = static_cast<int16_t>(UI_BOX_DATA[2].finalPos.x + 58),
+            .y = static_cast<int16_t>(UI_BOX_DATA[2].finalPos.y + 10),
+        };
         dtl::array<uint8_t, 16> string;
         sprintf(string.data(), "%d", MONEY);
-        getAtlasVanilla().renderSlow(string.data(), UI_BOX_DATA[2].finalPos.x + 58, UI_BOX_DATA[2].finalPos.y + 10, 4);
+        getAtlasVanilla().renderSlow(string.data(), 4, settings);
         data->bitString2.render(4);
     }
 
@@ -132,18 +135,26 @@ namespace
                 libgs_GsSetWorkBase(prim + 1);
             }
 
+            const RenderSettings settings{
+                .x = static_cast<int16_t>(box.finalPos.x + 0x8e),
+                .y = static_cast<int16_t>(box.finalPos.y + 9 + (i * 13)),
+            };
             dtl::array<uint8_t, 8> string;
             sprintf(string.data(), "%d", STATS_GAINS.get(stat));
-            getAtlasVanilla().renderSlow(string.data(), box.finalPos.x + 0x8e, box.finalPos.y + 9 + i * 13, layer);
+            getAtlasVanilla().renderSlow(string.data(), layer, settings);
         }
 
         for (int32_t i = 0; i < 6; i++)
         {
+            const RenderSettings settings{
+                .x = static_cast<int16_t>(box.finalPos.x + 0x44),
+                .y = static_cast<int16_t>(box.finalPos.y + 9 + (i * 13)),
+            };
             auto stat = static_cast<Stat>(i);
             dtl::array<uint8_t, 8> string;
 
             sprintf(string.data(), "%d", INITIAL_COMBAT_STATS[0].get(stat));
-            getAtlasVanilla().renderSlow(string.data(), box.finalPos.x + 0x44, box.finalPos.y + 9 + i * 13, layer);
+            getAtlasVanilla().renderSlow(string.data(), layer, settings);
         }
 
         setTextColor(previous_color);
@@ -258,8 +269,12 @@ namespace
             .width  = 176,
             .height = static_cast<int16_t>(BTL_END_BOX_TEXTBUFFER[0] == 0 ? 31 : 66),
         };
-
-        data->bitString1 = getAtlasVanilla().render(bitsString, finalPos.x + 10, finalPos.y + 10, LABEL_SETTINGS);
+        const RenderSettings settings{
+            .x     = static_cast<int16_t>(finalPos.x + 10),
+            .y     = static_cast<int16_t>(finalPos.y + 10),
+            .color = TEXT_COLOR_YELLOW,
+        };
+        data->bitString1 = getAtlasVanilla().render(bitsString, settings);
 
         createAnimatedUIBox(1, 0, 2, &finalPos, &startPos, tickBitBox, renderBitBox);
     }
@@ -273,7 +288,11 @@ namespace
             .width  = 176,
             .height = 31,
         };
-        data->bitString2 = getAtlasVanilla().render(bitsString, finalPos.x + 10, finalPos.y + 10);
+        const RenderSettings settings{
+            .x = static_cast<int16_t>(finalPos.x + 10),
+            .y = static_cast<int16_t>(finalPos.y + 10),
+        };
+        data->bitString2 = getAtlasVanilla().render(bitsString, settings);
         createAnimatedUIBox(2, 1, 0, &finalPos, &startPos, nullptr, renderFinalBalance);
     }
 
@@ -313,8 +332,14 @@ namespace
 
         data = dtl::make_unique<Data>();
         for (int32_t i = 0; i < statLabels.size(); i++)
-            data->statLabels[i] =
-                getAtlasVanilla().render(statLabels[i], finalPos.x + 10, finalPos.y + 9 + i * 13, LABEL_SETTINGS);
+        {
+            const RenderSettings settings{
+                .x     = static_cast<int16_t>(finalPos.x + 10),
+                .y     = static_cast<int16_t>(finalPos.y + 9 + (i * 13)),
+                .color = TEXT_COLOR_YELLOW,
+            };
+            data->statLabels[i] = getAtlasVanilla().render(statLabels[i], settings);
+        }
 
         createAnimatedUIBox(0, 0, 2, &finalPos, &startPos, tickPostBattleStatsBox, renderPostBattleStatsBox);
     }

--- a/src/BattleEndBox.cpp
+++ b/src/BattleEndBox.cpp
@@ -291,7 +291,7 @@ namespace
     {
         if (UI_BOX_DATA[id].state != 0) removeAnimatedUIBox(id, nullptr);
 
-        data.release();
+        data.reset();
     }
 
     void createPostBattleStatsBox()

--- a/src/CustomUI.cpp
+++ b/src/CustomUI.cpp
@@ -1,6 +1,8 @@
 #include "AtlasFont.hpp"
 #include "GameObjects.hpp"
+#include "Helper.hpp"
 #include "Timestamp.hpp"
+#include "extern/libc.hpp"
 
 namespace
 {
@@ -9,11 +11,8 @@ namespace
 
     void debugOverlayRender(int32_t instanceId)
     {
-        uint8_t buffer[64];
-        sprintf(buffer, "%u", RNG_STATE);
-        getAtlas5px().renderSlow(buffer, 1, RNG_POSITION);
-        sprintf(buffer, "%u", getTimestamp());
-        getAtlas5px().renderSlow(buffer, 1, TIME_POSITION);
+        getAtlas5px().renderSlow(format("%u", RNG_STATE).data(), 1, RNG_POSITION);
+        getAtlas5px().renderSlow(format("%u", getTimestamp()).data(), 1, TIME_POSITION);
     }
 } // namespace
 

--- a/src/CustomUI.cpp
+++ b/src/CustomUI.cpp
@@ -4,13 +4,16 @@
 
 namespace
 {
+    constexpr RenderSettings RNG_POSITION{.x = -159, .y = -119, .hasShadow = true};
+    constexpr RenderSettings TIME_POSITION{.x = -159, .y = -113, .hasShadow = true};
+
     void debugOverlayRender(int32_t instanceId)
     {
         uint8_t buffer[64];
         sprintf(buffer, "%u", RNG_STATE);
-        getAtlas5px().renderSlow(buffer, -159, -119, 1, {.hasShadow = true});
+        getAtlas5px().renderSlow(buffer, 1, RNG_POSITION);
         sprintf(buffer, "%u", getTimestamp());
-        getAtlas5px().renderSlow(buffer, -159, -113, 1, {.hasShadow = true});
+        getAtlas5px().renderSlow(buffer, 1, TIME_POSITION);
     }
 } // namespace
 

--- a/src/CustomUI.cpp
+++ b/src/CustomUI.cpp
@@ -4,8 +4,8 @@
 
 namespace
 {
-    constexpr RenderSettings RNG_POSITION{.x = -159, .y = -119, .hasShadow = true};
-    constexpr RenderSettings TIME_POSITION{.x = -159, .y = -113, .hasShadow = true};
+    constexpr RenderSettings RNG_POSITION{.x = -159, .y = -119, .baseClut = 1};
+    constexpr RenderSettings TIME_POSITION{.x = -159, .y = -113, .baseClut = 1};
 
     void debugOverlayRender(int32_t instanceId)
     {

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -41,6 +41,7 @@ namespace
 
     uint16_t getRowVanilla(uint16_t codepoint, uint8_t row)
     {
+        if(row > 10) return 0xFFFF;
         return getGlyphVanilla(codepoint)->pixelData[row];
     }
 
@@ -66,6 +67,7 @@ namespace
 
     uint16_t getGlyphRow(int32_t glyph, int32_t row)
     {
+        if(row > 10) return 0xFFFF;
         return GLYPH_DATA[glyph].pixelData[row];
     }
 
@@ -138,7 +140,7 @@ namespace
 extern "C"
 {
     Font vanillaFont = {
-        .height        = 11,
+        .height        = 12,
         .glyph_count   = 79,
         .getGlyphWidth = getGlyphWidth,
         .getGlyphRow   = getGlyphRow,

--- a/src/Helper.hpp
+++ b/src/Helper.hpp
@@ -57,6 +57,14 @@ public:
 constexpr auto SCREEN_WIDTH  = 320;
 constexpr auto SCREEN_HEIGHT = 240;
 
+template<size_t size = 256, typename... Args>
+constexpr dtl::array<uint8_t, size> format(const char* format, Args... args)
+{
+    dtl::array<uint8_t, size> buffer;
+    sprintf(buffer.data(), format, args...);
+    return buffer;
+}
+
 /*
  * Calculates whether a given time is within a given timeframe, where start being larger than end represents the
  * timeframe covering the day-change (or equivalent).

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -108,6 +108,7 @@ namespace
     {
         constexpr dtl::array<uint16_t, 16> noShadow{0x0000, 0x7FFF};
         constexpr dtl::array<uint16_t, 16> shadow{0x0000, 0x7FFF, 0x8000};
+        constexpr dtl::array<uint16_t, 16> greyShadow{0x0000, 0x8000, 0x7FFF};
         constexpr RECT rectNoShadow{
             .x      = 208,
             .y      = 489,
@@ -120,8 +121,15 @@ namespace
             .width  = 16,
             .height = 1,
         };
+        constexpr RECT rectGreyShadow{
+            .x      = 208,
+            .y      = 491,
+            .width  = 16,
+            .height = 1,
+        };
         libgpu_LoadImage(&rectNoShadow, noShadow.data());
         libgpu_LoadImage(&rectShadow, shadow.data());
+        libgpu_LoadImage(&rectGreyShadow, greyShadow.data());
     }
 
     void customInit()

--- a/src/Pause.cpp
+++ b/src/Pause.cpp
@@ -18,13 +18,13 @@ namespace
         .height = 24,
     };
     const RenderSettings PAUSE_SETTINGS{
-        .x         = PAUSE_BOX_POS.x,
-        .y         = PAUSE_BOX_POS.y,
-        .hasShadow = true,
-        .width     = PAUSE_BOX_POS.width,
-        .height    = PAUSE_BOX_POS.height,
-        .alignX    = AlignmentX::CENTER,
-        .alignY    = AlignmentY::CENTER,
+        .x        = PAUSE_BOX_POS.x,
+        .y        = PAUSE_BOX_POS.y,
+        .baseClut = 1,
+        .width    = PAUSE_BOX_POS.width,
+        .height   = PAUSE_BOX_POS.height,
+        .alignX   = AlignmentX::CENTER,
+        .alignY   = AlignmentY::CENTER,
     };
 
     bool hasPauseBox       = false;

--- a/src/Pause.cpp
+++ b/src/Pause.cpp
@@ -11,6 +11,22 @@
 
 namespace
 {
+    constexpr RECT PAUSE_BOX_POS{
+        .x      = -26,
+        .y      = -14,
+        .width  = 56,
+        .height = 24,
+    };
+    const RenderSettings PAUSE_SETTINGS{
+        .x         = PAUSE_BOX_POS.x,
+        .y         = PAUSE_BOX_POS.y,
+        .hasShadow = true,
+        .width     = PAUSE_BOX_POS.width,
+        .height    = PAUSE_BOX_POS.height,
+        .alignX    = AlignmentX::CENTER,
+        .alignY    = AlignmentY::CENTER,
+    };
+
     bool hasPauseBox       = false;
     uint32_t inputCurrent  = 0;
     uint32_t inputPrevious = 0;
@@ -29,11 +45,7 @@ namespace
         };
 
         libgs_GsSortBoxFill(&box, ACTIVE_ORDERING_TABLE, 7 - instance);
-        getAtlasVanilla().renderSlow("Pause",
-                                     UI_BOX_DATA[5].finalPos.x + 6,
-                                     UI_BOX_DATA[5].finalPos.y + 6,
-                                     0,
-                                     {.hasShadow = true});
+        getAtlasVanilla().renderSlow("Pause", 0, PAUSE_SETTINGS);
     };
 
     void pauseFrame()
@@ -77,14 +89,7 @@ extern "C"
     {
         if (hasPauseBox) return;
 
-        RECT rect{
-            .x      = -26,
-            .y      = -14,
-            .width  = 56,
-            .height = 24,
-        };
-
-        createStaticUIBox(5, 1, 0, &rect, nullptr, renderPauseBox);
+        createStaticUIBox(5, 1, 0, &PAUSE_BOX_POS, nullptr, renderPauseBox);
         hasPauseBox = true;
         playSound(0, 3);
     }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -96,8 +96,14 @@ void* operator new(size_t size)
     return libapi_malloc3(size);
 }
 
-void* operator new[](size_t size) {
+void* operator new[](size_t size)
+{
     return libapi_malloc3(size);
+}
+
+void operator delete(void* p) noexcept
+{
+    libapi_free3(p);
 }
 
 void operator delete(void* p, size_t size) noexcept

--- a/src/extern/dtl/algorithm.hpp
+++ b/src/extern/dtl/algorithm.hpp
@@ -6,11 +6,16 @@ namespace dtl
 {
     template<typename T> using Comparator = bool(const T& left, const T& right);
 
+    template<typename T> remove_reference_t<T>&& move(T&& val)
+    {
+        return static_cast<typename remove_reference<T>::type&&>(val);
+    }
+
     template<typename T> constexpr void swap(T& left, T& right)
     {
-        T tmp = left;
-        left  = right;
-        right = tmp;
+        T tmp = dtl::move(left);
+        left  = dtl::move(right);
+        right = dtl::move(tmp);
     }
 
     template<typename T> constexpr bool less(const T& left, const T& right)
@@ -53,10 +58,5 @@ namespace dtl
             *output = *begin;
 
         return output;
-    }
-
-    template<typename T> remove_reference_t<T>&& move(T&& val)
-    {
-        return static_cast<typename remove_reference<T>::type&&>(val);
     }
 } // namespace dtl

--- a/src/extern/dtl/runtime_array.hpp
+++ b/src/extern/dtl/runtime_array.hpp
@@ -32,7 +32,14 @@ namespace dtl
             dtl::copy(other.begin(), other.end(), begin());
         }
         constexpr runtime_array(runtime_array&& other) { swap(*this, other); }
-        constexpr runtime_array& operator=(runtime_array other)
+        constexpr runtime_array& operator=(const runtime_array& other)
+        {
+            elem_count = other.elem_count;
+            elements   = make_unique<T[]>(elem_count);
+            dtl::copy(other.begin(), other.end(), begin());
+            return *this;
+        }
+        constexpr runtime_array& operator=(runtime_array&& other)
         {
             swap(*this, other);
             return *this;


### PR DESCRIPTION
The front-end change is, that the `RenderSettings` struct has grown to contain position, size and alignment, allowing strings to be built once and ready.

There is also a new `format` function, that wraps `sprintf` in a more convenient form.

In the backend there have been some optimizations (such as moving instead of copying) and bug fixes (such as empty string rendering).